### PR TITLE
Implement the Unmarshaler and Marshaler interfaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ BenchmarkAtomicBoolToggle-4   	169871972	         7.02 ns/op  # <--- This packag
 
 - [@barryz](https://github.com/barryz)
   - Added the `Toggle` method
+- [@LucasRouckhout](https://github.com/LucasRouckhout)
+  - Implemented JSON Unmarshal and Marshal interface

--- a/bool.go
+++ b/bool.go
@@ -85,6 +85,6 @@ func (ab *AtomicBool) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-    ab.SetTo(v)
-    return nil
+	ab.SetTo(v)
+	return nil
 }

--- a/bool.go
+++ b/bool.go
@@ -73,13 +73,13 @@ func (ab *AtomicBool) SetToIf(old, new bool) (set bool) {
 	return atomic.CompareAndSwapInt32((*int32)(ab), o, n)
 }
 
-// Marshall behaves the same as if the AtomicBool is a builtin.bool.
+// MarshalJSON behaves the same as if the AtomicBool is a builtin.bool.
 // NOTE: There's no lock during the process, usually it shouldn't be called with other methods in parallel.
 func (ab *AtomicBool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ab.IsSet())
 }
 
-// Unmarshall behaves the same as if the AtomicBool is a builtin.bool.
+// UnmarshalJSON behaves the same as if the AtomicBool is a builtin.bool.
 // NOTE: There's no lock during the process, usually it shouldn't be called with other methods in parallel.
 func (ab *AtomicBool) UnmarshalJSON(b []byte) error {
 	var v bool

--- a/bool.go
+++ b/bool.go
@@ -83,10 +83,10 @@ func (ab *AtomicBool) MarshalJSON() ([]byte, error) {
 // NOTE: There's no lock during the process, usually it shouldn't be called with other methods in parallel.
 func (ab *AtomicBool) UnmarshalJSON(b []byte) error {
 	var v bool
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
+	err := json.Unmarshal(b, &v)
 
-	ab.SetTo(v)
-	return nil
+	if err == nil {
+		ab.SetTo(v)
+	}
+	return err
 }

--- a/bool.go
+++ b/bool.go
@@ -4,8 +4,6 @@ package abool
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"sync/atomic"
 )
 
@@ -82,16 +80,11 @@ func (ab *AtomicBool) MarshalJSON() ([]byte, error) {
 
 // Unmarshall normal bool's into AtomicBool
 func (ab *AtomicBool) UnmarshalJSON(b []byte) error {
-	var v interface{}
+	var v bool
 	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
 
-	switch value := v.(type) {
-	case bool:
-		ab.SetTo(value)
-		return nil
-	default:
-		return errors.New(fmt.Sprintf("%s is an invalid JSON representation for an AtomicBool\n", b))
-	}
+    ab.SetTo(v)
+    return nil
 }

--- a/bool.go
+++ b/bool.go
@@ -73,12 +73,14 @@ func (ab *AtomicBool) SetToIf(old, new bool) (set bool) {
 	return atomic.CompareAndSwapInt32((*int32)(ab), o, n)
 }
 
-// Marshal an AtomicBool into JSON like a normal bool
+// Marshall behaves the same as if the AtomicBool is a builtin.bool.
+// NOTE: There's no lock during the process, usually it shouldn't be called with other methods in parallel.
 func (ab *AtomicBool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ab.IsSet())
 }
 
-// Unmarshall normal bool's into AtomicBool
+// Unmarshall behaves the same as if the AtomicBool is a builtin.bool.
+// NOTE: There's no lock during the process, usually it shouldn't be called with other methods in parallel.
 func (ab *AtomicBool) UnmarshalJSON(b []byte) error {
 	var v bool
 	if err := json.Unmarshal(b, &v); err != nil {

--- a/bool_test.go
+++ b/bool_test.go
@@ -182,49 +182,35 @@ func TestRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFalseUnmarshall(t *testing.T) {
-	// Marshall a normal bool into JSON byte slice
-	b, err := json.Marshal(false)
-	if err != nil {
-		t.Error(err)
+func TestJSONUnmarshall(t *testing.T) {
+	// Table of cases
+	cases := []struct {
+		boolean bool
+		abool   *AtomicBool
+	}{
+		{true, NewBool(true)},
+		{false, NewBool(false)},
 	}
 
-	// Create an AtomicBool
-	v := New()
+	for _, c := range cases {
+		b, err := json.Marshal(c.boolean)
+		if err != nil {
+			t.Error(err)
+		}
 
-	// Try to unmarshall the JSON byte slice of a
-	// a normal bool into an AtomicBool
-	err = v.UnmarshalJSON(b)
-	if err != nil {
-		t.Error(err)
-	}
+		// Create an AtomicBool
+		v := New()
 
-	// Check if our AtomicBool is set to false
-	if v.IsSet() == true {
-		t.Errorf("Expected AtomicBool to represent false but IsSet() returns true")
-	}
-}
+		// Try to unmarshall the JSON byte slice
+		// of a normal boolean into an AtomicBool
+		err = v.UnmarshalJSON(b)
+		if err != nil {
+			t.Error(err)
+		}
 
-func TestTrueUnmarshall(t *testing.T) {
-	// Marshall a normal bool into JSON byte slice
-	b, err := json.Marshal(true)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Create an AtomicBool
-	v := New()
-
-	// Try to unmarshall the JSON byte slice of a
-	// a normal bool into an AtomicBool
-	err = v.UnmarshalJSON(b)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Check if our AtomicBool is set to false
-	if v.IsSet() == false {
-		t.Errorf("Expected AtomicBool to represent true but IsSet() returns false. %+v", v)
+		if v.IsSet() != c.abool.IsSet() {
+			t.Errorf("Expected AtomicBool to represent %t but actual value was %t", c.abool.IsSet(), v.IsSet())
+		}
 	}
 }
 

--- a/bool_test.go
+++ b/bool_test.go
@@ -182,7 +182,7 @@ func TestRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestJSONUnmarshall(t *testing.T) {
+func TestJSONUnmarshal(t *testing.T) {
 	// Table of cases
 	cases := []struct {
 		boolean bool

--- a/bool_test.go
+++ b/bool_test.go
@@ -1,6 +1,7 @@
 package abool
 
 import (
+	"encoding/json"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -179,6 +180,52 @@ func TestRace(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestFalseUnmarshall(t *testing.T) {
+	// Marshall a normal bool into JSON byte slice
+	b, err := json.Marshal(false)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create an AtomicBool
+	v := New()
+
+	// Try to unmarshall the JSON byte slice of a
+	// a normal bool into an AtomicBool
+	err = v.UnmarshalJSON(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check if our AtomicBool is set to false
+	if v.IsSet() == true {
+		t.Errorf("Expected AtomicBool to represent false but IsSet() returns true")
+	}
+}
+
+func TestTrueUnmarshall(t *testing.T) {
+	// Marshall a normal bool into JSON byte slice
+	b, err := json.Marshal(true)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create an AtomicBool
+	v := New()
+
+	// Try to unmarshall the JSON byte slice of a
+	// a normal bool into an AtomicBool
+	err = v.UnmarshalJSON(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check if our AtomicBool is set to false
+	if v.IsSet() == false {
+		t.Errorf("Expected AtomicBool to represent true but IsSet() returns false. %+v", v)
+	}
 }
 
 func ExampleAtomicBool() {


### PR DESCRIPTION
_I saw the last commit to the repo was done like 10 months ago so this is probably going to be a useless PR but here it goes. If you think this might be a useful addition you can review, discuss and possibly merge this PR. I believe in adding your changes back upstream so here are some I made._

I recently used the `AtomicBool` type by copy pasting the [`bool.go`](bool.go) package into my own source code (while off course including the MIT License notice as required) instead of using it as a dependency since I needed to be able to use `AtomicBool` in a struct which gets Unmarshalled from a JSON file. Thus I needed to implement the [Marshaler](https://golang.org/pkg/encoding/json/#Marshaler) and [Unmarshaler](https://golang.org/pkg/encoding/json/#Unmarshaler) interfaces.

This PR implements those Interfaces and adds two test for the Unmarshall function. The reason for not including tests for the Marshall function is that this function is a trivial wrapper around `bool` marshaling. So I would have essentially been testing the standard library.

```go
func (ab *AtomicBool) MarshalJSON() ([]byte, error) {
	return json.Marshal(ab.IsSet())
}
```

This functionality makes AtomicBool easier to use inside structs` since it allows for easy serializing and de-serializing from JSON.