### PR TITLE
Hide internal int32 data

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -30,17 +30,17 @@ type AtomicBool struct {
 
 // Set sets the Boolean to true.
 func (ab *AtomicBool) Set() {
-	atomic.StoreInt32((*int32)(&ab.boolean), 1)
+	atomic.StoreInt32(&ab.boolean, 1)
 }
 
 // UnSet sets the Boolean to false.
 func (ab *AtomicBool) UnSet() {
-	atomic.StoreInt32((*int32)(&ab.boolean), 0)
+	atomic.StoreInt32(&ab.boolean, 0)
 }
 
 // IsSet returns whether the Boolean is true.
 func (ab *AtomicBool) IsSet() bool {
-	return atomic.LoadInt32((*int32)(&ab.boolean))&1 == 1
+	return atomic.LoadInt32(&ab.boolean)&1 == 1
 }
 
 // IsNotSet returns whether the Boolean is false.
@@ -51,9 +51,9 @@ func (ab *AtomicBool) IsNotSet() bool {
 // SetTo sets the boolean with given Boolean.
 func (ab *AtomicBool) SetTo(yes bool) {
 	if yes {
-		atomic.StoreInt32((*int32)(&ab.boolean), 1)
+		atomic.StoreInt32(&ab.boolean, 1)
 	} else {
-		atomic.StoreInt32((*int32)(&ab.boolean), 0)
+		atomic.StoreInt32(&ab.boolean, 0)
 	}
 }
 
@@ -79,7 +79,7 @@ func (ab *AtomicBool) SetToIf(old, new bool) (set bool) {
 	if new {
 		n = 1
 	}
-	return atomic.CompareAndSwapInt32((*int32)(&ab.boolean), o, n)
+	return atomic.CompareAndSwapInt32(&ab.boolean, o, n)
 }
 
 // MarshalJSON behaves the same as if the AtomicBool is a builtin.bool.

--- a/bool.go
+++ b/bool.go
@@ -58,8 +58,15 @@ func (ab *AtomicBool) SetTo(yes bool) {
 }
 
 // Toggle inverts the Boolean then returns the value before inverting.
+// Based on: https://github.com/uber-go/atomic/blob/3504dfaa1fa414923b1c8693f45d2f6931daf229/bool_ext.go#L40
 func (ab *AtomicBool) Toggle() bool {
-	return atomic.AddInt32((*int32)(&ab.boolean), 1)&1 == 0
+	var old bool
+	for {
+		old = ab.IsSet()
+		if ab.SetToIf(old, !old) {
+			return old
+		}
+	}
 }
 
 // SetToIf sets the Boolean to new only if the Boolean matches the old.

--- a/bool.go
+++ b/bool.go
@@ -24,21 +24,23 @@ func NewBool(ok bool) *AtomicBool {
 // AtomicBool is an atomic Boolean.
 // Its methods are all atomic, thus safe to be called by multiple goroutines simultaneously.
 // Note: When embedding into a struct one should always use *AtomicBool to avoid copy.
-type AtomicBool int32
+type AtomicBool struct {
+	boolean int32
+}
 
 // Set sets the Boolean to true.
 func (ab *AtomicBool) Set() {
-	atomic.StoreInt32((*int32)(ab), 1)
+	atomic.StoreInt32((*int32)(&ab.boolean), 1)
 }
 
 // UnSet sets the Boolean to false.
 func (ab *AtomicBool) UnSet() {
-	atomic.StoreInt32((*int32)(ab), 0)
+	atomic.StoreInt32((*int32)(&ab.boolean), 0)
 }
 
 // IsSet returns whether the Boolean is true.
 func (ab *AtomicBool) IsSet() bool {
-	return atomic.LoadInt32((*int32)(ab)) == 1
+	return atomic.LoadInt32((*int32)(&ab.boolean))&1 == 1
 }
 
 // IsNotSet returns whether the Boolean is false.
@@ -49,10 +51,15 @@ func (ab *AtomicBool) IsNotSet() bool {
 // SetTo sets the boolean with given Boolean.
 func (ab *AtomicBool) SetTo(yes bool) {
 	if yes {
-		atomic.StoreInt32((*int32)(ab), 1)
+		atomic.StoreInt32((*int32)(&ab.boolean), 1)
 	} else {
-		atomic.StoreInt32((*int32)(ab), 0)
+		atomic.StoreInt32((*int32)(&ab.boolean), 0)
 	}
+}
+
+// Toggle inverts the Boolean then returns the value before inverting.
+func (ab *AtomicBool) Toggle() bool {
+	return atomic.AddInt32((*int32)(&ab.boolean), 1)&1 == 0
 }
 
 // SetToIf sets the Boolean to new only if the Boolean matches the old.
@@ -65,7 +72,7 @@ func (ab *AtomicBool) SetToIf(old, new bool) (set bool) {
 	if new {
 		n = 1
 	}
-	return atomic.CompareAndSwapInt32((*int32)(ab), o, n)
+	return atomic.CompareAndSwapInt32((*int32)(&ab.boolean), o, n)
 }
 
 // MarshalJSON behaves the same as if the AtomicBool is a builtin.bool.


### PR DESCRIPTION
Hide the data structure in a struct with unexported field.

Before, accessing the int32 was possible from within another package:
```go
package main

import (
	"fmt"
	"sync/atomic"

	"github.com/tevino/abool"
)

var cond = abool.New()

func main() {
	atomic.StoreInt32((*int32)(cond), 5)
	// 5 is uneven and true
	fmt.Println(atomic.LoadInt32((*int32)(cond)))
	fmt.Println(cond.IsSet())

	// as cond is true, it should be set to false
	cond.SetToIf(true, false)

	// Still true, as it's still set to 5 != 1
	fmt.Println(cond.IsSet())
	fmt.Println(atomic.LoadInt32((*int32)(cond)))
}
```
By hiding the int32 in a struct, accessing it from the outside is no longer possible.

Benchmarks show no noticeable difference in performance.



This revealed another bug in the Toggle function, which I am unsure how to solve. I will open an issue. #7 